### PR TITLE
Fix broken link to angular cheatsheet

### DIFF
--- a/src/app/environment/environment.component.html
+++ b/src/app/environment/environment.component.html
@@ -79,7 +79,7 @@
     <a href="https://kapeli.com/cheat_sheets/npm.docset/Contents/Resources/Documents/index" target="_blank">
       <strong>npm Cheat Sheet</strong>
     </a><br>
-    <a href="https://malcoded.com/static/68c150aaaee9e8056f44fb81a08799ad/aaced/angular-cli-cheat-sheet.webp" download="angular_cli_cheat_sheet" target="_blank"><strong>Angular CLI Cheat Sheet</strong></a>
+    <a href="https://malcoded.com/angular-cheat-sheet/" target="_blank"><strong>Angular CLI Cheat Sheet</strong></a>
   </p>
   <div class="ui warning message">
     <p>Official documentation:</p>


### PR DESCRIPTION
Link to Angular Cheatsheet was broken (404 not found), replaced it with link to cheatsheet from same site